### PR TITLE
added some interactivity support to Gw2Specialization

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,6 +54,8 @@ module.exports = {
     }],
 
     'mocha/no-exclusive-tests': 'error',
+
+    'jsx-a11y/no-static-element-interactions': 'warn'
   },
   settings: {
     'import/resolver': 'webpack',

--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ import { Gw2Specialization } from 'armory-component-ui';
 |-|-|-|-|
 | id | `number` | n/a | yes |
 | activeTraits | `Array<number>` | Major traits that are active. | no |
+| onTraitClick | `({ id: number; isMajorTrait: boolean; }) => void` | Callback function called when a trait icon is clicked. | no |
+| minorTraitClass | `string` | Class name applied to the minor trait icons. | no |
+| majorTraitClass | `string` | Class name applied to the major trait icons. | no |
 
 #### `<Gw2Trait />`
 

--- a/src/components/Gw2Specialization/_stories.js
+++ b/src/components/Gw2Specialization/_stories.js
@@ -2,11 +2,9 @@
 
 import React from 'react';
 import Gw2Specialization from './';
-import { decorateAction } from '@storybook/addon-actions';
+import { action } from '@storybook/addon-actions';
 
-const traitClick = decorateAction([
-  (args) => Object.values(args[0]),
-])('trait clicked');
+const traitClick = action('trait clicked');
 
 storiesOf('Gw2Specialization', module)
   .add('default', () => <App><Gw2Specialization id={57} /></App>)

--- a/src/components/Gw2Specialization/_stories.js
+++ b/src/components/Gw2Specialization/_stories.js
@@ -2,6 +2,11 @@
 
 import React from 'react';
 import Gw2Specialization from './';
+import { decorateAction } from '@storybook/addon-actions';
+
+const traitClick = decorateAction([
+  (args) => Object.values(args[0]),
+])('trait clicked');
 
 storiesOf('Gw2Specialization', module)
   .add('default', () => <App><Gw2Specialization id={57} /></App>)
@@ -12,4 +17,10 @@ storiesOf('Gw2Specialization', module)
       <Gw2Specialization id={57} />
     </App>
   )
-  .add('loading', () => <App><Gw2Specialization /></App>);
+  .add('loading', () => <App><Gw2Specialization /></App>)
+  .add('interactive', () =>
+    <App>
+      <Gw2Specialization id={112233} onTraitClick={traitClick} majorTraitClass={'cursor-pointer'} minorTraitClass={'cursor-help'} />
+      <Gw2Specialization id={5} onTraitClick={traitClick} majorTraitClass={'cursor-pointer'} minorTraitClass={'cursor-help'} />
+    </App>
+  );

--- a/src/components/Gw2Specialization/index.js
+++ b/src/components/Gw2Specialization/index.js
@@ -3,7 +3,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import type { Traits, Specialization as SpecializationType } from 'flowTypes';
+import type { Traits, Specialization as SpecializationType, TraitClickCallback } from 'flowTypes';
 
 import Specialization from '../Specialization';
 import actions from '../../actions/gw2';
@@ -28,6 +28,9 @@ class Gw2Specialization extends Component<*> {
     activeTraits?: Array<number>,
     fetch: ([number]) => void,
     specialization: SpecializationType,
+    onTraitClick?: TraitClickCallback,
+    minorTraitClass?: string,
+    majorTraitClass?: string,
   };
 
   componentDidMount () {

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -35,15 +35,22 @@ const Icon = ({ name, size, className, src, button, children, style, sizePx, onC
   } catch (ex) {
     imageSrc = '';
   }
+  const cssProps = {};
+  cssProps.className = cx(styles.container, styles[size], className, button && styles.button);
+  cssProps.style = buildStyle({ style, src, name, imageSrc, sizePx });
 
-  return (
+  return onClick ? (
+    <a
+      {...props}
+      {...cssProps}
+      onClick={onClick}
+    >
+      {children}
+    </a>
+  ) : (
     <div
       {...props}
-      className={cx(styles.container, styles[size], className, button && styles.button)}
-      style={buildStyle({ style, src, name, imageSrc, sizePx })}
-      role="button"
-      tabIndex="0"
-      onClick={(event) => onClick && onClick(event)}
+      {...cssProps}
     >
       {children}
     </div>

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -15,6 +15,7 @@ export type IconProps = {
   style?: {
     [string]: ?string,
   },
+  onClick?: (SyntheticEvent<*>) => void,
 };
 
 const buildStyle = ({ style, src, name, imageSrc, sizePx }) => {
@@ -26,7 +27,7 @@ const buildStyle = ({ style, src, name, imageSrc, sizePx }) => {
   };
 };
 
-const Icon = ({ name, size, className, src, button, children, style, sizePx, ...props }: IconProps) => {
+const Icon = ({ name, size, className, src, button, children, style, sizePx, onClick, ...props }: IconProps) => {
   let imageSrc;
 
   try {
@@ -40,6 +41,9 @@ const Icon = ({ name, size, className, src, button, children, style, sizePx, ...
       {...props}
       className={cx(styles.container, styles[size], className, button && styles.button)}
       style={buildStyle({ style, src, name, imageSrc, sizePx })}
+      role="button"
+      tabIndex="0"
+      onClick={(event) => onClick && onClick(event)}
     >
       {children}
     </div>

--- a/src/components/Specialization/index.js
+++ b/src/components/Specialization/index.js
@@ -11,16 +11,14 @@ import SpecializationIcon from './SpecializationIcon';
 
 const getTrait = (id, traits, error) => traits[id] || { error };
 const isActive = (id, activeTraits) => activeTraits.indexOf(id) >= 0;
-const getTraitClickCallback = (id, isMajorTrait, callback) => () => {
-  id && callback && callback({ id, isMajorTrait });
-};
+const getTraitClickCallback = (id, callback) => (id && callback ? () => { callback(id); } : undefined);
 const layoutTraits = (ids, traits, activeTraits, error, onTraitClick, majorTraitClass) => ids.map((id, index) =>
   <Trait
     key={id || index}
     className={cx(styles.minorTraitColumn, majorTraitClass)}
     data={getTrait(id, traits, error)}
     active={isActive(id, activeTraits)}
-    onClick={getTraitClickCallback(id, true, onTraitClick)}
+    onClick={getTraitClickCallback(id, onTraitClick)}
   />
 );
 
@@ -69,7 +67,7 @@ const Specialization = ({
           active
           className={cx(styles.minorTraitColumn, minorTraitClass)}
           data={getTrait(minorTraits[0], traits, error)}
-          onClick={getTraitClickCallback(minorTraits[0], false, onTraitClick)}
+          onClick={getTraitClickCallback(minorTraits[0], onTraitClick)}
         />
 
         <div className={styles.majorTraitColumn}>
@@ -80,7 +78,7 @@ const Specialization = ({
           active
           className={cx(styles.minorTraitColumn, minorTraitClass)}
           data={getTrait(minorTraits[1], traits, error)}
-          onClick={getTraitClickCallback(minorTraits[1], false, onTraitClick)}
+          onClick={getTraitClickCallback(minorTraits[1], onTraitClick)}
         />
 
         <div className={styles.majorTraitColumn}>
@@ -91,7 +89,7 @@ const Specialization = ({
           active
           className={cx(styles.minorTraitColumn, minorTraitClass)}
           data={getTrait(minorTraits[2], traits, error)}
-          onClick={getTraitClickCallback(minorTraits[2], false, onTraitClick)}
+          onClick={getTraitClickCallback(minorTraits[2], onTraitClick)}
         />
 
         <div className={styles.majorTraitColumn}>

--- a/src/components/Specialization/index.js
+++ b/src/components/Specialization/index.js
@@ -1,8 +1,9 @@
 // @flow
 
-import type { Specialization as SpecType, Traits } from 'flowTypes';
+import type { Specialization as SpecType, Traits, TraitClickCallback } from 'flowTypes';
 
 import React from 'react';
+import cx from 'classnames';
 import colours from '../../styles/colours';
 import styles from './styles.less';
 import Trait from '../Trait';
@@ -10,11 +11,16 @@ import SpecializationIcon from './SpecializationIcon';
 
 const getTrait = (id, traits, error) => traits[id] || { error };
 const isActive = (id, activeTraits) => activeTraits.indexOf(id) >= 0;
-const layoutTraits = (ids, traits, activeTraits, error) => ids.map((id, index) =>
+const getTraitClickCallback = (id, isMajorTrait, callback) => () => {
+  id && callback && callback({ id, isMajorTrait });
+};
+const layoutTraits = (ids, traits, activeTraits, error, onTraitClick, majorTraitClass) => ids.map((id, index) =>
   <Trait
     key={id || index}
+    className={cx(styles.minorTraitColumn, majorTraitClass)}
     data={getTrait(id, traits, error)}
     active={isActive(id, activeTraits)}
+    onClick={getTraitClickCallback(id, true, onTraitClick)}
   />
 );
 
@@ -29,9 +35,19 @@ type Props = {
   traits: Traits,
   activeTraits: Array<number>,
   specialization: SpecType,
+  onTraitClick: TraitClickCallback,
+  minorTraitClass: string,
+  majorTraitClass: string,
 };
 
-const Specialization = ({ activeTraits, traits, specialization }: Props) => {
+const Specialization = ({
+  activeTraits,
+  traits,
+  specialization,
+  onTraitClick,
+  minorTraitClass,
+  majorTraitClass,
+}: Props) => {
   const minorTraits = specialization.minor_traits || emptyTraits;
   const majorTraits = specialization.major_traits || emptyTraits;
   const error = specialization.error;
@@ -51,32 +67,35 @@ const Specialization = ({ activeTraits, traits, specialization }: Props) => {
       <div className={styles.traits}>
         <Trait
           active
-          className={styles.minorTraitColumn}
+          className={cx(styles.minorTraitColumn, minorTraitClass)}
           data={getTrait(minorTraits[0], traits, error)}
+          onClick={getTraitClickCallback(minorTraits[0], false, onTraitClick)}
         />
 
         <div className={styles.majorTraitColumn}>
-          {layoutTraits(majorTraits.slice(0, 3), traits, activeTraits, error)}
+          {layoutTraits(majorTraits.slice(0, 3), traits, activeTraits, error, onTraitClick, majorTraitClass)}
         </div>
 
         <Trait
           active
-          className={styles.minorTraitColumn}
+          className={cx(styles.minorTraitColumn, minorTraitClass)}
           data={getTrait(minorTraits[1], traits, error)}
+          onClick={getTraitClickCallback(minorTraits[1], false, onTraitClick)}
         />
 
         <div className={styles.majorTraitColumn}>
-          {layoutTraits(majorTraits.slice(3, 6), traits, activeTraits, error)}
+          {layoutTraits(majorTraits.slice(3, 6), traits, activeTraits, error, onTraitClick, majorTraitClass)}
         </div>
 
         <Trait
           active
-          className={styles.minorTraitColumn}
+          className={cx(styles.minorTraitColumn, minorTraitClass)}
           data={getTrait(minorTraits[2], traits, error)}
+          onClick={getTraitClickCallback(minorTraits[2], false, onTraitClick)}
         />
 
         <div className={styles.majorTraitColumn}>
-          {layoutTraits(majorTraits.slice(6, 9), traits, activeTraits, error)}
+          {layoutTraits(majorTraits.slice(6, 9), traits, activeTraits, error, onTraitClick, majorTraitClass)}
         </div>
       </div>
     </div>

--- a/src/components/Specialization/styles.less
+++ b/src/components/Specialization/styles.less
@@ -43,7 +43,7 @@
   display: flex;
   flex-flow: column;
 
-  div {
+  div, a {
     clip-path: inset(2px 2px 2px 2px);
   }
 

--- a/src/components/Trait/index.js
+++ b/src/components/Trait/index.js
@@ -20,9 +20,10 @@ type Props = {
   tooltipTextOverride?: string,
   size?: number,
   inlineText?: string,
+  onClick?: (SyntheticEvent<*>) => void,
 };
 
-const Trait = ({ data, className, active, tooltipTextOverride, size, inlineText }: Props) => (
+const Trait = ({ data, className, active, tooltipTextOverride, size, inlineText, onClick }: Props) => (
   <TooltipTrigger type="trait" data={tooltipTextOverride || data}>
     <ResourceLink text={data && data.name} href={buildLink(inlineText, data && data.name)}>
       <Icon
@@ -30,6 +31,7 @@ const Trait = ({ data, className, active, tooltipTextOverride, size, inlineText 
         src={data && data.icon}
         style={{ backgroundColor: data && data.icon && colours._black }}
         sizePx={size}
+        onClick={onClick}
       />
     </ResourceLink>
   </TooltipTrigger>

--- a/src/flowTypes.js
+++ b/src/flowTypes.js
@@ -249,3 +249,10 @@ export type Notifications = {
 };
 
 export type UserAchievementsMap = {};
+
+export type TraitClick = {
+  id: number,
+  isMajorTrait: boolean,
+};
+
+export type TraitClickCallback = TraitClick => void;

--- a/src/flowTypes.js
+++ b/src/flowTypes.js
@@ -250,9 +250,4 @@ export type Notifications = {
 
 export type UserAchievementsMap = {};
 
-export type TraitClick = {
-  id: number,
-  isMajorTrait: boolean,
-};
-
-export type TraitClickCallback = TraitClick => void;
+export type TraitClickCallback = number => void;

--- a/stories/styles.css
+++ b/stories/styles.css
@@ -31,3 +31,11 @@
   width: 200px;
   height: 100px;
 }
+
+.cursor-pointer {
+  cursor: pointer;
+}
+
+.cursor-help {
+  cursor: help;
+}


### PR DESCRIPTION
Added an `onTraitClick` callback prop as well as props for passing down class names for the trait icons, as per #8.

I also lowered eslint level for `jsx-a11y/no-static-element-interactions` after it complained about a `div` with an `onClick` handler. There are [ways to fix that](https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/91), but I didn't want to include bigger changes to the code, such as changing the `div`s into `button`s or updating the eslint dependency versions and fixing the breaking changes introduced in them, so in the end I just lowered the level to a warning and I'll let you decide how to handle it in the future.